### PR TITLE
Add CSS classes to 'google_scholar_search' and 'pdf_download' links

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -69,7 +69,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
 
       $display['google_scholar_search'] = array(
         '#type' => 'item',
-        '#markup' => l(t('Search for this publication on Google Scholar'), "http://scholar.google.ca/scholar?q=\"$search_term\""),
+        '#markup' => l(t('Search for this publication on Google Scholar'), "http://scholar.google.ca/scholar?q=\"$search_term\"", array('attributes' => array('class' => 'scholar-google-scholar-search-link'))),
         '#weight' => 0,
       );
     }
@@ -157,8 +157,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
     $filename = str_replace(":", "_", $object->id);
     $display['pdf_download'] = array(
       '#type' => 'item',
-      '#title' => t('Download'),
-      '#markup' => l(t('PDF'), "islandora/object/$object->id/datastream/PDF/download/$filename.pdf"),
+      '#markup' => l(t('Download PDF'), "islandora/object/$object->id/datastream/PDF/download/citation.pdf", array('attributes' => array('class' => 'scholar-pdf-download-link'))),
       '#weight' => $display['pdf_download']['#weight'],
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2459)

# What does this Pull Request do?

Adds CSS classes to 'google_scholar_search' and 'pdf_download' links

# What's new?
Using CSS, one can now choose to style or hide the links

# How should this be tested?

* Download the updated utilities.inc
* drush cc all
* Load a scholar citation object in your web browser
* Observe new classes on 'google_scholar_search' and 'pdf_download' links

`<a href="http://scholar.google.ca/scholar?q=&quot;doi:10.1021/jacs.7b09268&quot;" class="scholar-google-scholar-search-link">Search for this publication on Google Scholar</a>
`

`<a href="/islandora/object/work%3A59/datastream/PDF/download/citation.pdf" class="scholar-pdf-download-link">Download PDF</a>
`

# Additional Notes:
The PDF download link originally used #title to produce the "Download:" text prior to the link.  The #title portion has been eliminated in favor of placing the text inside the link, which enables a singular output which can be styled all together. 

# Interested parties
@DonRichards @bryjbrown